### PR TITLE
Issue91 feat/game/cleanup ゲーム終了時のクリーンアップ処理を追加

### DIFF
--- a/game_service/client/match_api_client.py
+++ b/game_service/client/match_api_client.py
@@ -10,13 +10,16 @@ class MatchApiClient:
     @staticmethod
     def send_game_result(data):
         url = f"{MATCH_SERVICE}/matches/finish"
-        response = requests.post(url, json=data)
+        try:
+            response = requests.post(url, json=data)
 
-        if response.status_code >= 400:
-            error_detail = response.json()
-            logger.critical(
-                f"POST {url}\n"
-                f"status: {response.status_code}\n"
-                f"respones: {error_detail}\n"
-                f"Sent Data: {data}"
-            )
+            if response.status_code >= 400:
+                error_detail = response.json()
+                logger.critical(
+                    f"POST {url}\n"
+                    f"status: {response.status_code}\n"
+                    f"respones: {error_detail}\n"
+                    f"Sent Data: {data}"
+                )
+        except Exception as e:
+            logger.critical(f"POST {url}\nSent Data: {data}\nerror: {e}")

--- a/game_service/fe/src/app/game/[matchId]/page.js
+++ b/game_service/fe/src/app/game/[matchId]/page.js
@@ -81,6 +81,14 @@ export default function Game() {
             setRemainingTime(calcRemaingTime(endTimeRef.current));
             startTimer();
           }
+          if (
+            parsedMessage.type === "game.finish.message" &&
+            parsedMessage.message === "gameover"
+          ) {
+            console.log(parsedMessage)
+            const results = parsedMessage.results;
+            alert("game over:\n" + results.map(r => `User ${r.userId}: ${r.score}`).join("\n"));
+          }
         } catch (error) {
           console.error("Failed to parse WebSocket message:", error);
         }

--- a/game_service/fe/src/app/game/[matchId]/page.js
+++ b/game_service/fe/src/app/game/[matchId]/page.js
@@ -85,7 +85,6 @@ export default function Game() {
             parsedMessage.type === "game.finish.message" &&
             parsedMessage.message === "gameover"
           ) {
-            console.log(parsedMessage)
             const results = parsedMessage.results;
             alert("game over:\n" + results.map(r => `User ${r.userId}: ${r.score}`).join("\n"));
           }

--- a/game_service/fe/src/app/game/[matchId]/page.js
+++ b/game_service/fe/src/app/game/[matchId]/page.js
@@ -86,7 +86,9 @@ export default function Game() {
             parsedMessage.message === "gameover"
           ) {
             const results = parsedMessage.results;
-            alert("game over:\n" + results.map(r => `User ${r.userId}: ${r.score}`).join("\n"));
+            alert(
+              `game·over:\n${results.map((r) => `User ${r.userId}: ${r.score}`).join("\n")}`,
+            );
           }
         } catch (error) {
           console.error("Failed to parse WebSocket message:", error);

--- a/game_service/realtime_pingpong/consumers.py
+++ b/game_service/realtime_pingpong/consumers.py
@@ -68,11 +68,11 @@ class ActionHandler:
         if match_dict is None:
             return
         game_controller = match_dict[MatchManager.KEY_GAME_CONTROLLER]
-        game = game_controller.game
-        if game.state == PingPong.GameState.GAME_OVER:
-            return MatchManager.remove_match(match_id)
-        # gameが終了していない限り、matchは終了しない
         return game_controller.disconnect_event(player_id)
+
+    @staticmethod
+    def handle_game_end(match_id):
+        MatchManager.remove_match(match_id)
 
 
 class GameConsumer(AsyncWebsocketConsumer):
@@ -143,3 +143,4 @@ class GameConsumer(AsyncWebsocketConsumer):
         channel_layer = get_channel_layer()
         event["type"] = "game.finish.message"
         await channel_layer.group_send(group_name, event)
+        ActionHandler.handle_game_end(self.match_id)

--- a/game_service/realtime_pingpong/consumers.py
+++ b/game_service/realtime_pingpong/consumers.py
@@ -134,12 +134,12 @@ class GameConsumer(AsyncWebsocketConsumer):
         event["type"] = "game.message"
         await channel_layer.group_send(group_name, event)
 
-    async def finish_message(self, event):
+    async def game_finish_message(self, event):
         await self.send(text_data=json.dumps(event))
         await self.disconnect()
 
     @staticmethod
     async def finish_game(event, group_name):
         channel_layer = get_channel_layer()
-        event["type"] = "finish.message"
+        event["type"] = "game.finish.message"
         await channel_layer.group_send(group_name, event)

--- a/game_service/realtime_pingpong/consumers.py
+++ b/game_service/realtime_pingpong/consumers.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
 import json
+from dataclasses import dataclass
 
 from channels.generic.websocket import AsyncWebsocketConsumer
 from channels.layers import get_channel_layer
@@ -143,4 +143,4 @@ class GameConsumer(AsyncWebsocketConsumer):
         channel_layer = get_channel_layer()
         event["type"] = "game.finish.message"
         await channel_layer.group_send(group_name, event)
-        ActionHandler.handle_game_end(self.match_id)
+        ActionHandler.handle_game_end(int(group_name))

--- a/game_service/realtime_pingpong/game_controller.py
+++ b/game_service/realtime_pingpong/game_controller.py
@@ -90,13 +90,16 @@ class GameController:
                     group_name,
                 )
                 await asyncio.sleep(self.FRAME_DURATION)
-            self.__game.state = PingPong.GameState.GAME_OVER
-            result = self.__get_game_result(group_name)
-            MatchApiClient.send_game_result(result)
-            result["message"] = GameConsumer.MessageType.MSG_GAME_OVER
-            GameConsumer.finish_game(result, group_name)
+            await self.process_game_result(group_name)
         except asyncio.CancelledError:
             pass
+
+    async def process_game_result(self, group_name):
+        self.__game.state = PingPong.GameState.GAME_OVER
+        result = self.__get_game_result(group_name)
+        MatchApiClient.send_game_result(result)
+        result["message"] = GameConsumer.MessageType.MSG_GAME_OVER
+        await GameConsumer.finish_game(result, group_name)
 
     def __calc_unix_time(self, time):
         return int(time.timestamp())

--- a/game_service/realtime_pingpong/game_controller.py
+++ b/game_service/realtime_pingpong/game_controller.py
@@ -95,6 +95,9 @@ class GameController:
             pass
 
     async def process_game_result(self, group_name):
+        # 遅延インポートで循環インポートを防ぐ
+        from realtime_pingpong.consumers import GameConsumer
+
         self.__game.state = PingPong.GameState.GAME_OVER
         result = self.__get_game_result(group_name)
         MatchApiClient.send_game_result(result)

--- a/game_service/realtime_pingpong/game_controller.py
+++ b/game_service/realtime_pingpong/game_controller.py
@@ -81,7 +81,7 @@ class GameController:
                 self.__game.update()
                 await GameConsumer.group_send(
                     {
-                        "message": GameConsumer.MessageType.MSG_UPDATE.value,
+                        "message": GameConsumer.MessageType.MSG_UPDATE,
                         "data": {
                             "state": self.__game.get_state(),
                         },
@@ -90,6 +90,7 @@ class GameController:
                 )
                 await asyncio.sleep(self.FRAME_DURATION)
             self.__game.state = PingPong.GameState.GAME_OVER
+            GameConsumer.finish_game({}, group_name)
         except asyncio.CancelledError:
             pass
 

--- a/game_service/tests/realtime_pingpong/test_action_handler.py
+++ b/game_service/tests/realtime_pingpong/test_action_handler.py
@@ -127,12 +127,6 @@ class ActionHandlerTestCase(unittest.IsolatedAsyncioTestCase):
         await ActionHandler.handle_game_connection(1, 2)
         self.mock_game_controller.reconnect_event.assert_called_once_with(str(1), 2)
 
-    async def test_handle_disconnection_remove_match(self):
-        with patch("core.match_manager.MatchManager.remove_match") as mock_remove_match:
-            self.mock_game.state = PingPong.GameState.GAME_OVER
-            ActionHandler.handle_disconnection(1, 2)
-            mock_remove_match.assert_called_once_with(1)
-
     async def test_handle_disconnection_disconnect_event_in_progress(self):
         with patch("core.match_manager.MatchManager.remove_match") as mock_remove_match:
             self.mock_game.state = PingPong.GameState.IN_PROGRESS
@@ -153,3 +147,9 @@ class ActionHandlerTestCase(unittest.IsolatedAsyncioTestCase):
             ActionHandler.handle_disconnection(1, 2)
             self.mock_game_controller.disconnect_event.assert_called_once_with(2)
             mock_remove_match.assert_not_called()
+
+    async def test_handle_game_end(self):
+        with patch("core.match_manager.MatchManager.remove_match") as mock_remove_match:
+            self.mock_game.state = PingPong.GameState.GAME_OVER
+            ActionHandler.handle_game_end(1)
+            mock_remove_match.assert_called_once_with(1)

--- a/game_service/tests/realtime_pingpong/test_game_consumer.py
+++ b/game_service/tests/realtime_pingpong/test_game_consumer.py
@@ -1,0 +1,29 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from core.match_manager import MatchManager
+from realtime_pingpong.consumers import GameConsumer
+
+
+class TestGameController(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        MatchManager.remove_match = MagicMock(return_value=None)
+        self.patcher = patch(
+            "channels.layers.get_channel_layer", return_value=MagicMock()
+        )
+        self.mock_get_channel_layer = self.patcher.start()
+        self.mock_channel_layer = self.mock_get_channel_layer.return_value
+        self.result = {
+            "matchId": 1,
+            "results": [
+                {"userId": 1, "score": 2},
+                {"userId": 2, "score": 6},
+            ],
+        }
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    async def test_finish_game(self):
+        await GameConsumer.finish_game(self.result, "1")
+        MatchManager.remove_match.assert_called_once_with(1)

--- a/game_service/tests/realtime_pingpong/test_game_consumer.py
+++ b/game_service/tests/realtime_pingpong/test_game_consumer.py
@@ -6,24 +6,18 @@ from realtime_pingpong.consumers import GameConsumer
 
 
 class TestGameConsumer(unittest.IsolatedAsyncioTestCase):
-    def setUp(self):
+    @patch("channels.layers.get_channel_layer", return_value=MagicMock())
+    async def test_finish_game(self, mock_get_channel_layer):
         MatchManager.remove_match = MagicMock(return_value=None)
-        self.patcher = patch(
-            "channels.layers.get_channel_layer", return_value=MagicMock()
+
+        await GameConsumer.finish_game(
+            {
+                "matchId": 1,
+                "results": [
+                    {"userId": 1, "score": 2},
+                    {"userId": 2, "score": 6},
+                ],
+            },
+            "1",
         )
-        self.mock_get_channel_layer = self.patcher.start()
-        self.mock_channel_layer = self.mock_get_channel_layer.return_value
-        self.result = {
-            "matchId": 1,
-            "results": [
-                {"userId": 1, "score": 2},
-                {"userId": 2, "score": 6},
-            ],
-        }
-
-    def tearDown(self):
-        self.patcher.stop()
-
-    async def test_finish_game(self):
-        await GameConsumer.finish_game(self.result, "1")
         MatchManager.remove_match.assert_called_once_with(1)

--- a/game_service/tests/realtime_pingpong/test_game_consumer.py
+++ b/game_service/tests/realtime_pingpong/test_game_consumer.py
@@ -1,11 +1,11 @@
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from core.match_manager import MatchManager
 from realtime_pingpong.consumers import GameConsumer
 
 
-class TestGameController(unittest.IsolatedAsyncioTestCase):
+class TestGameConsumer(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         MatchManager.remove_match = MagicMock(return_value=None)
         self.patcher = patch(

--- a/game_service/tests/realtime_pingpong/test_game_controller.py
+++ b/game_service/tests/realtime_pingpong/test_game_controller.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from client.match_api_client import MatchApiClient
 from core.pingpong import PingPong
+from realtime_pingpong.consumers import GameConsumer
 from realtime_pingpong.game_controller import GameController
 
 
@@ -25,6 +26,7 @@ class TestGameController(unittest.IsolatedAsyncioTestCase):
         self.controller._GameController__player_manager = MagicMock()
 
         MatchApiClient.send_game_result = MagicMock(return_value=None)
+        GameConsumer.finish_game = AsyncMock(return_value=None)
 
     async def test_start_game(self):
         """ゲームを開始できるかのテスト"""


### PR DESCRIPTION
## 概要
<!--対応内容-->
game終了後のcleanup処理を追加
- wsのコネクションの切断
- matchの削除

## 関連するチケット
<!--関連するissueやドキュメントなど-->
close #91 


## レビューしてほしい点
<!--特に気をつけてレビューして欲しい点があれば-->
- プレイヤーが二人とも切断した場合、ゲームを終了させるか？
終了させる場合試合の結果をどうするか？
[追記]
切断されてもゲームを続ける方針で実装

- feのdir以外（フロントは仮で作っています）
## 動作確認方法
<!--共有しないといけない点があれば-->


## 参考文献
<!--共有すべき参考文献があれば-->


## 備考

