### PR TITLE
fix: pingpong add_playerのロジックを変更

### DIFF
--- a/game_service/core/pingpong.py
+++ b/game_service/core/pingpong.py
@@ -278,11 +278,15 @@ class PingPong:
             self.__right_player = Player(
                 player_id, Paddle(Screen.WIDTH, Screen.HEIGHT / 2)
             )
-        self.__state == self.GameState.READY_TO_START if all(
-            [self.__left_player, self.__right_player]
-        ) else self.GameState.WAITING_FOR_SECOND_PLAYER
+        self.__state = (
+            self.GameState.READY_TO_START
+            if all([self.__left_player, self.__right_player])
+            else self.GameState.WAITING_FOR_SECOND_PLAYER
+        )
 
     def player_action(self, id, key):
+        if self.state != self.GameState.IN_PROGRESS:
+            return
         if id == self.__left_player.id:
             self.__left_player.move_paddle(key)
         elif id == self.__right_player.id:

--- a/game_service/core/pingpong.py
+++ b/game_service/core/pingpong.py
@@ -260,24 +260,27 @@ class PingPong:
     def right_player(self):
         return self.__right_player
 
-    def add_player(self, player_id):
+    def add_player(self, player_id, index):
         if (
             self.__state != self.GameState.WAITING_FOR_FIRST_PLAYER
             and self.__state != self.GameState.WAITING_FOR_SECOND_PLAYER
         ):
             # すでにプレイヤーが作成されている時はなにもしない
             return
-        if self.__state == self.GameState.WAITING_FOR_FIRST_PLAYER:
+
+        # indexの順にplayerを追加
+        # 0 = left player, 1 = right player
+        if index == 0 and self.left_player is None:
             self.__left_player = Player(
                 player_id, Paddle(Screen.LEFTEST_POS, Screen.HEIGHT / 2)
             )
-            self.__state = self.GameState.WAITING_FOR_SECOND_PLAYER
-            return
-        # プレイヤーの再接続
-        if self.__left_player.id == player_id:
-            return
-        self.__right_player = Player(player_id, Paddle(Screen.WIDTH, Screen.HEIGHT / 2))
-        self.__state = self.GameState.READY_TO_START
+        elif index == 1 and self.right_player is None:
+            self.__right_player = Player(
+                player_id, Paddle(Screen.WIDTH, Screen.HEIGHT / 2)
+            )
+        self.__state == self.GameState.READY_TO_START if all(
+            [self.__left_player, self.__right_player]
+        ) else self.GameState.WAITING_FOR_SECOND_PLAYER
 
     def player_action(self, id, key):
         if id == self.__left_player.id:

--- a/game_service/realtime_pingpong/consumers.py
+++ b/game_service/realtime_pingpong/consumers.py
@@ -36,7 +36,7 @@ class ActionHandler:
 
         game_contoroller = match_dict[MatchManager.KEY_GAME_CONTROLLER]
         game = game_contoroller.game
-        game.add_player(user_id)
+        game.add_player(user_id, match.players.index(user_id))
         return (True, 200)
 
     @staticmethod
@@ -44,7 +44,7 @@ class ActionHandler:
         type = json.get("type")
         key = json.get("key")
         user_id = json.get("userid")
-        if type is None or key is None or user_id is None:
+        if not all([type, key, user_id]):
             return
         if not user_id.isdigit():
             return

--- a/game_service/tests/core/test_pingpong.py
+++ b/game_service/tests/core/test_pingpong.py
@@ -270,8 +270,8 @@ class TestPingPong(unittest.TestCase):
         self.game.ball.x_pos = ball.get("x")
         self.game.ball.y_pos = ball.get("y")
 
-        self.game.add_player(left_player.get("id"))
-        self.game.add_player(right_player.get("id"))
+        self.game.add_player(left_player.get("id"), 0)
+        self.game.add_player(right_player.get("id"), 1)
 
         self.game.left_player.paddle.y_pos = left_player.get("y")
         self.game.left_player.score = left_player.get("score")
@@ -279,54 +279,86 @@ class TestPingPong(unittest.TestCase):
         self.game.right_player.paddle.y_pos = right_player.get("y")
         self.game.right_player.score = right_player.get("score")
 
-    def test_add_player(self):
+    def test_add_left_player_first(self):
         self.assertEqual(self.game.state, PingPong.GameState.WAITING_FOR_FIRST_PLAYER)
 
-        self.game.add_player(1)
+        self.game.add_player(1, 0)
         self.assertIsNotNone(self.game.left_player)
         self.assertIsNone(self.game.right_player)
 
         self.assertEqual(self.game.state, PingPong.GameState.WAITING_FOR_SECOND_PLAYER)
-        self.game.add_player(2)
+        self.game.add_player(2, 1)
         self.assertEqual(self.game.state, PingPong.GameState.READY_TO_START)
         self.assertIsNotNone(self.game.left_player)
         self.assertIsNotNone(self.game.right_player)
 
         # 再接続時
-        self.game.add_player(1)
+        self.game.add_player(1, 0)
         self.assertEqual(self.game.state, PingPong.GameState.READY_TO_START)
-        self.game.add_player(2)
+        self.game.add_player(2, 1)
         self.assertEqual(self.game.state, PingPong.GameState.READY_TO_START)
 
-    def test_add_player_reconncect(self):
+    def test_add_right_player_first(self):
         self.assertEqual(self.game.state, PingPong.GameState.WAITING_FOR_FIRST_PLAYER)
-        self.game.add_player(1)
+
+        self.game.add_player(1, 1)
+        self.assertIsNotNone(self.game.right_player)
+        self.assertIsNone(self.game.left_player)
+
+        self.assertEqual(self.game.state, PingPong.GameState.WAITING_FOR_SECOND_PLAYER)
+        self.game.add_player(2, 0)
+        self.assertEqual(self.game.state, PingPong.GameState.READY_TO_START)
+        self.assertIsNotNone(self.game.left_player)
+        self.assertIsNotNone(self.game.right_player)
+
+        # 再接続時
+        self.game.add_player(2, 1)
+        self.assertEqual(self.game.state, PingPong.GameState.READY_TO_START)
+        self.game.add_player(1, 0)
+        self.assertEqual(self.game.state, PingPong.GameState.READY_TO_START)
+
+    def test_add_player_left_player_reconncect(self):
+        self.assertEqual(self.game.state, PingPong.GameState.WAITING_FOR_FIRST_PLAYER)
+        self.game.add_player(1, 0)
         self.assertEqual(self.game.state, PingPong.GameState.WAITING_FOR_SECOND_PLAYER)
         self.assertIsNotNone(self.game.left_player)
         self.assertIsNone(self.game.right_player)
 
         # 再接続時
-        self.game.add_player(1)
+        self.game.add_player(1, 0)
         self.assertEqual(self.game.state, PingPong.GameState.WAITING_FOR_SECOND_PLAYER)
         self.assertIsNotNone(self.game.left_player)
         self.assertIsNone(self.game.right_player)
 
+    def test_add_player_right_player_reconncect(self):
+        self.assertEqual(self.game.state, PingPong.GameState.WAITING_FOR_FIRST_PLAYER)
+        self.game.add_player(1, 1)
+        self.assertEqual(self.game.state, PingPong.GameState.WAITING_FOR_SECOND_PLAYER)
+        self.assertIsNotNone(self.game.right_player)
+        self.assertIsNone(self.game.left_player)
+
+        # 再接続時
+        self.game.add_player(1, 1)
+        self.assertEqual(self.game.state, PingPong.GameState.WAITING_FOR_SECOND_PLAYER)
+        self.assertIsNotNone(self.game.right_player)
+        self.assertIsNone(self.game.left_player)
+
     def test_add_player_reconncect_in_progress(self):
-        self.game.add_player(1)
-        self.game.add_player(2)
+        self.game.add_player(1, 0)
+        self.game.add_player(2, 1)
         self.assertIsNotNone(self.game.left_player)
         self.assertIsNotNone(self.game.right_player)
         self.game.state = PingPong.GameState.IN_PROGRESS
 
         # 再接続時
-        self.game.add_player(1)
+        self.game.add_player(1, 0)
         self.assertEqual(self.game.state, PingPong.GameState.IN_PROGRESS)
-        self.game.add_player(2)
+        self.game.add_player(2, 1)
         self.assertEqual(self.game.state, PingPong.GameState.IN_PROGRESS)
 
     def test_player_action(self):
-        self.game.add_player(1)
-        self.game.add_player(2)
+        self.game.add_player(1, 0)
+        self.game.add_player(2, 1)
 
         keys = self.game.left_player.keys
         upkey = keys.get(Player.UP)
@@ -342,8 +374,8 @@ class TestPingPong(unittest.TestCase):
         self.assertTrue(self.game.right_player.paddle.y_pos > right_pos)
 
     def test_player_action_no_action(self):
-        self.game.add_player(1)
-        self.game.add_player(2)
+        self.game.add_player(1, 0)
+        self.game.add_player(2, 1)
 
         left_pos = self.game.left_player.paddle.y_pos
         right_pos = self.game.right_player.paddle.y_pos

--- a/game_service/tests/core/test_pingpong.py
+++ b/game_service/tests/core/test_pingpong.py
@@ -272,6 +272,8 @@ class TestPingPong(unittest.TestCase):
 
         self.game.add_player(left_player.get("id"), 0)
         self.game.add_player(right_player.get("id"), 1)
+        # game開始
+        self.game.state = self.game.GameState.IN_PROGRESS
 
         self.game.left_player.paddle.y_pos = left_player.get("y")
         self.game.left_player.score = left_player.get("score")
@@ -365,6 +367,8 @@ class TestPingPong(unittest.TestCase):
         downkey = keys.get(Player.DOWN)
         left_pos = self.game.left_player.paddle.y_pos
         right_pos = self.game.right_player.paddle.y_pos
+        # game開始
+        self.game.state = self.game.GameState.IN_PROGRESS
 
         # paddleの位置が上に移動しているはず
         self.game.player_action(1, upkey)
@@ -379,6 +383,8 @@ class TestPingPong(unittest.TestCase):
 
         left_pos = self.game.left_player.paddle.y_pos
         right_pos = self.game.right_player.paddle.y_pos
+        # game開始
+        self.game.state = self.game.GameState.IN_PROGRESS
 
         # 未登録のkeyなのでなにも起こらない
         self.game.player_action(1, "KeyA")

--- a/game_service/tests/realtime_pingpong/test_action_handler.py
+++ b/game_service/tests/realtime_pingpong/test_action_handler.py
@@ -35,7 +35,9 @@ class ActionHandlerTestCase(unittest.IsolatedAsyncioTestCase):
     def test_handle_new_connection_success(self):
         result, status_code = ActionHandler.handle_new_connection(1, 2)
 
-        self.mock_game_controller.game.add_player.assert_called_once_with(2)
+        self.mock_game_controller.game.add_player.assert_called_once_with(
+            2, self.mock_match.players.index(2)
+        )
         self.assertTrue(result)
         self.assertEqual(status_code, 200)
 


### PR DESCRIPTION
## 概要
<!--対応内容-->
- add_playerにindexの引数を渡すようにしました
- そうすることで、matchに登録された時点で、どのプレイヤーがleftかrightかわかるようになります
- フロントを実装する際にこちらの仕様の方が都合がいいです
- テストも追加しました


## 関連するチケット
<!--関連するissueやドキュメントなど-->
<!--close #issue number-->
close #123 


## レビューしてほしい点
<!--特に気をつけてレビューして欲しい点があれば-->


## 動作確認方法
<!--共有しないといけない点があれば-->


## 参考文献
<!--共有すべき参考文献があれば-->


## 備考

