### PR TITLE
ピンポンゲームのフロントを実装

### DIFF
--- a/docker_env/game.env
+++ b/docker_env/game.env
@@ -1,6 +1,6 @@
 REDIS_HOST=game_redis
 REDIS_PORT=6379
-FE_SERVER=http://localhost:3000
+FE_SERVER=http://localhost:8080
 MATCH_SERVICE=https://matches.42.fr
 SSL_PORT=8004
 SERVER_NAME=games.42.fr

--- a/spa/config.js
+++ b/spa/config.js
@@ -3,6 +3,7 @@ const config = {
     userService: "http://localhost:9000",
     matchService: "http://localhost:8003",
     gameService: "http://localhost:8001",
+    gameRealtimeService: "ws://localhost:8001",
     authService: "http://localhost:8000",
   },
   production: {

--- a/spa/main.js
+++ b/spa/main.js
@@ -4,6 +4,7 @@ window.SPA = SPA;
 import Game, { setupGame } from "./views/Game.js";
 import GameResult from "./views/GameResult.js";
 import Home from "./views/Home.js";
+import InitMatch, { setupInitMatch } from "./views/InitMatch.js";
 import Login, { setupLogin } from "./views/Login.js";
 import LoginVerify, { setupLoginVerify } from "./views/LoginVerify.js";
 import NotFound from "./views/NotFound.js";
@@ -22,5 +23,6 @@ SPA.route("/login", Login, setupLogin);
 SPA.route("/login/verify", LoginVerify, setupLoginVerify);
 SPA.route("/game", Game, setupGame);
 SPA.route("/game/result", GameResult);
+SPA.route("/game/setup", InitMatch), setupInitMatch;
 
 SPA.init({ containerId: "app" });

--- a/spa/main.js
+++ b/spa/main.js
@@ -23,6 +23,6 @@ SPA.route("/login", Login, setupLogin);
 SPA.route("/login/verify", LoginVerify, setupLoginVerify);
 SPA.route("/game", Game, setupGame);
 SPA.route("/game/result", GameResult);
-SPA.route("/game/setup", InitMatch), setupInitMatch;
+SPA.route("/game/setup", InitMatch, setupInitMatch);
 
 SPA.init({ containerId: "app" });

--- a/spa/main.js
+++ b/spa/main.js
@@ -2,7 +2,7 @@ import SPA from "./spa.js";
 window.SPA = SPA;
 
 import Game, { setupGame } from "./views/Game.js";
-import GameResult from "./views/GameResult.js";
+import GameResult, { setupGameResult } from "./views/GameResult.js";
 import Home from "./views/Home.js";
 import InitMatch, { setupInitMatch } from "./views/InitMatch.js";
 import Login, { setupLogin } from "./views/Login.js";
@@ -22,7 +22,7 @@ SPA.route("/signup/verify", SignUpVerify, setupSignUpVerify);
 SPA.route("/login", Login, setupLogin);
 SPA.route("/login/verify", LoginVerify, setupLoginVerify);
 SPA.route("/game", Game, setupGame);
-SPA.route("/game/result", GameResult);
+SPA.route("/game/result", GameResult, setupGameResult);
 SPA.route("/game/setup", InitMatch, setupInitMatch);
 
 SPA.init({ containerId: "app" });

--- a/spa/services/game/PlayerActionHandler.js
+++ b/spa/services/game/PlayerActionHandler.js
@@ -12,7 +12,7 @@ const PlayerActionHandler = {
     }
     const message = JSON.stringify({
       type: "game.paddle_move",
-      key: e.code,
+      key: event.code,
       userid: stateManager.state?.userId,
     });
     WsConnectionManager.sendMessage(message);

--- a/spa/services/game/PlayerActionHandler.js
+++ b/spa/services/game/PlayerActionHandler.js
@@ -1,3 +1,4 @@
+import stateManager from "../../stateManager.js";
 import WsConnectionManager from "./WsConnectionManager.js";
 
 const PlayerActionHandler = {
@@ -12,7 +13,7 @@ const PlayerActionHandler = {
     const message = JSON.stringify({
       type: "game.paddle_move",
       key: e.code,
-      // userid: userid,
+      userid: stateManager.state?.userId,
     });
     WsConnectionManager.sendMessage(message);
   },

--- a/spa/services/game/WsConnectionManager.js
+++ b/spa/services/game/WsConnectionManager.js
@@ -24,7 +24,11 @@ const wsEventHandler = {
       const gameMessage = parsedMessage.message;
       if (type === "game.message" && gameMessage === "update") {
         const updatedState = parsedMessage.data.state;
-        gameRender.renderGame(updatedState);
+        gameRender.renderGame({
+          ball: updatedState.ball,
+          leftPlayer: updatedState.left_player,
+          rightPlayer: updatedState.right_player,
+        });
       } else if (type === "game.message" && gameMessage === "timer") {
         const endTime = Number(parsedMessage.end_time) * 1000; // Unixタイム(秒) → ミリ秒に変換
         startTimer(endTime);

--- a/spa/services/game/WsConnectionManager.js
+++ b/spa/services/game/WsConnectionManager.js
@@ -3,6 +3,7 @@ import SPA from "../../spa.js";
 import stateManager from "../../stateManager.js";
 import { calcRemaingTime } from "../../utils/timerHelper.js";
 import { gameRender } from "../../views/Game.js";
+import PlayerActionHandler from "./PlayerActionHandler.js";
 
 const startTimer = (endTime) => {
   const interval = setInterval(() => {
@@ -35,10 +36,6 @@ const wsEventHandler = {
         startTimer(endTime);
       } else if (type === "game.finish.message" && gameMessage === "gameover") {
         const results = parsedMessage.results;
-        alert(
-          `game·over:\n${results.map((r) => `User ${r.userId}: ${r.score}`).join("\n")}`,
-        );
-
         const highestScore = results.reduce((max, r) => {
           const score = parseInt(r.score, 10);
           return score > max ? score : max;
@@ -48,6 +45,8 @@ const wsEventHandler = {
         const userId = stateManager.state?.userid;
         const win = userId && (results.some(r => r.userId === userId.toString() && r.score === highestScore.toString()));
 
+        WsConnectionManager.disconnect();
+        PlayerActionHandler.cleanup();
         SPA.navigate("/game/result", {
           left: leftScore,
           right: rightScore,

--- a/spa/services/game/WsConnectionManager.js
+++ b/spa/services/game/WsConnectionManager.js
@@ -1,4 +1,5 @@
 import config from "../../config.js";
+import SPA from "../../spa.js";
 import stateManager from "../../stateManager.js";
 import { calcRemaingTime } from "../../utils/timerHelper.js";
 import { gameRender } from "../../views/Game.js";
@@ -37,6 +38,21 @@ const wsEventHandler = {
         alert(
           `game·over:\n${results.map((r) => `User ${r.userId}: ${r.score}`).join("\n")}`,
         );
+
+        const highestScore = results.reduce((max, r) => {
+          const score = parseInt(r.score, 10);
+          return score > max ? score : max;
+        }, 0);
+        const leftScore = results[0]?.score;
+        const rightScore = results[1]?.score;
+        const userId = stateManager.state?.userid;
+        const win = userId && (results.some(r => r.userId === userId.toString() && r.score === highestScore.toString()));
+
+        SPA.navigate("/game/result", {
+          left: leftScore,
+          right: rightScore,
+          win: win
+        });
       }
     } catch (error) {
       console.error("Failed to parse WebSocket message:", error);

--- a/spa/services/game/WsConnectionManager.js
+++ b/spa/services/game/WsConnectionManager.js
@@ -42,6 +42,7 @@ const wsEventHandler = {
   },
   handleError(message) {
     console.error("WebSocket error:", message);
+    gameRender.renderError("failed to establish game connection.");
   },
 };
 
@@ -53,6 +54,7 @@ const WsConnectionManager = {
     this.socket = new WebSocket(
       `ws://${config.gameService}/games/ws/enter-room/${matchId}`,
     );
+    this.registerEventHandler();
   },
 
   disconnect() {
@@ -72,10 +74,6 @@ const WsConnectionManager = {
   },
 
   registerEventHandler() {
-    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
-      console.error("Socket is not open. Unable to send message.");
-      return;
-    }
     this.socket.onopen = this.eventHandler.handleOpen.bind(this.eventHandler);
     this.socket.onmessage = this.eventHandler.handleMessage.bind(
       this.eventHandler,

--- a/spa/services/game/WsConnectionManager.js
+++ b/spa/services/game/WsConnectionManager.js
@@ -8,7 +8,7 @@ const startTimer = (endTime) => {
   const interval = setInterval(() => {
     const remainingTime = calcRemaingTime(endTime);
     gameRender.renderTimer(remainingTime);
-    if (time <= 0) {
+    if (remainingTime <= 0) {
       clearInterval(interval);
     }
   }, 1000); // 1秒ごとに実行

--- a/spa/services/game/WsConnectionManager.js
+++ b/spa/services/game/WsConnectionManager.js
@@ -41,11 +41,11 @@ const wsEventHandler = {
         }, 0);
         const leftScore = results[0]?.score;
         const rightScore = results[1]?.score;
-        const userId = stateManager.state?.userid;
+        const userId = stateManager.state?.userId;
         const win = userId && (results.some(r => r.userId == userId && r.score === highestScore));
 
-        WsConnectionManager.disconnect();
         PlayerActionHandler.cleanup();
+        WsConnectionManager.disconnect();
         SPA.navigate("/game/result", {
           left: leftScore,
           right: rightScore,

--- a/spa/services/game/WsConnectionManager.js
+++ b/spa/services/game/WsConnectionManager.js
@@ -37,13 +37,12 @@ const wsEventHandler = {
       } else if (type === "game.finish.message" && gameMessage === "gameover") {
         const results = parsedMessage.results;
         const highestScore = results.reduce((max, r) => {
-          const score = parseInt(r.score, 10);
-          return score > max ? score : max;
+          return r.score > max ? r.score : max;
         }, 0);
         const leftScore = results[0]?.score;
         const rightScore = results[1]?.score;
         const userId = stateManager.state?.userid;
-        const win = userId && (results.some(r => r.userId === userId.toString() && r.score === highestScore.toString()));
+        const win = userId && (results.some(r => r.userId == userId && r.score === highestScore));
 
         WsConnectionManager.disconnect();
         PlayerActionHandler.cleanup();

--- a/spa/services/game/WsConnectionManager.js
+++ b/spa/services/game/WsConnectionManager.js
@@ -1,4 +1,5 @@
 import config from "../../config.js";
+import stateManager from "../../stateManager.js";
 import { calcRemaingTime } from "../../utils/timerHelper.js";
 import { gameRender } from "../../views/Game.js";
 
@@ -14,7 +15,7 @@ const startTimer = (endTime) => {
 
 const wsEventHandler = {
   handleOpen(message) {
-    console.log("Connected to match");
+    console.log("Connected to game");
   },
   handleMessage(message) {
     try {
@@ -51,8 +52,9 @@ const WsConnectionManager = {
   eventHandler: wsEventHandler,
 
   connect(matchId) {
+    // TODO: uriを変更する
     this.socket = new WebSocket(
-      `ws://${config.gameService}/games/ws/enter-room/${matchId}`,
+      `${config.gameRealtimeService}/games/ws/enter-room/${matchId}/${stateManager.state?.userId}`,
     );
     this.registerEventHandler();
   },

--- a/spa/spa.js
+++ b/spa/spa.js
@@ -13,7 +13,7 @@ const SPA = (() => {
     routes[path] = { view, setup };
   };
 
-  const navigate = (path, params = {}, replace = false) => {
+  const navigate = (path, params = null, replace = false) => {
     if (replace) {
       history.replaceState({}, "", path);
     } else {

--- a/spa/spa.js
+++ b/spa/spa.js
@@ -13,22 +13,22 @@ const SPA = (() => {
     routes[path] = { view, setup };
   };
 
-  const navigate = (path, params = null, replace = false) => {
+  const navigate = async (path, params = null, replace = false) => {
     if (replace) {
       history.replaceState({}, "", path);
     } else {
       history.pushState({}, "", path);
     }
-    renderRoute(params);
+    await renderRoute(params);
   };
 
-  const renderRoute = (params) => {
+  const renderRoute = async (params) => {
     const path = window.location.pathname;
     const route = routes[path] || routes["/404"];
     if (route && container) {
       container.innerHTML = route.view(params);
       if (route.setup) {
-        route.setup();
+        await route.setup();
       }
     }
   };

--- a/spa/spa.js
+++ b/spa/spa.js
@@ -13,20 +13,20 @@ const SPA = (() => {
     routes[path] = { view, setup };
   };
 
-  const navigate = (path, replace = false) => {
+  const navigate = (path, params = {}, replace = false) => {
     if (replace) {
       history.replaceState({}, "", path);
     } else {
       history.pushState({}, "", path);
     }
-    renderRoute();
+    renderRoute(params);
   };
 
-  const renderRoute = () => {
+  const renderRoute = (params) => {
     const path = window.location.pathname;
     const route = routes[path] || routes["/404"];
     if (route && container) {
-      container.innerHTML = route.view();
+      container.innerHTML = route.view(params);
       if (route.setup) {
         route.setup();
       }

--- a/spa/views/Game.js
+++ b/spa/views/Game.js
@@ -139,13 +139,11 @@ export const gameRender = {
   renderPlayerNames(players = []) {
     const nameClasses = [".js-left-player", ".js-right-player"];
     nameClasses.forEach((nameClass, index) => {
-      const player = players[index];
+      const playerName = players[index] ?? "";
       const element = document.querySelector(nameClass);
 
-      if (element && player) {
-        element.textContent = player.name;
-      } else if (element) {
-        element.textContent = "";
+      if (element) {
+        element.textContent = playerName;
       }
     });
   },
@@ -177,7 +175,8 @@ export const setupGame = async () => {
       return
     }
     gameRender.renderGame();
-    const names = await Promise.all(stateManager.state.players.map(async (id) => await fetchUsername(id)));
+    const names = await Promise.all(stateManager.state.players.map(fetchUsername));
+    console.log(names)
     gameRender.renderPlayerNames(names);
     WsConnectionManager.connect(stateManager.state.matchId);
     PlayerActionHandler.registerEventHandler();

--- a/spa/views/Game.js
+++ b/spa/views/Game.js
@@ -159,7 +159,7 @@ export const gameRender = {
 };
 
 const fetchUsername = async (userid) => {
-  const res = await fetch(`${config.userService}/users?userid=${userid}`);
+  const res = await fetch(`${config.userService}/users?userId=${userid}`);
   if (!res.ok) {
     throw new Error(`failed to fetch user data: ${res.status}`);
   }

--- a/spa/views/Game.js
+++ b/spa/views/Game.js
@@ -35,7 +35,7 @@ export default function Game() {
         </div>
       </div>
       <h1 class="game-timer display-3 js-game-timer p-0 m-0">60</h1>
-      <h1 class="js-game-error fs-1 text-center text-danger fw-bold text-wrap">Error occured.</h1>
+      <h1 class="js-game-error fs-1 text-center text-danger fw-bold text-wrap"></h1>
       <p class="js-game-error-detail fs-2 text-center text-danger text-wrap"></p>
     </div>
     `;
@@ -168,10 +168,10 @@ const fetchUsername = async (userid) => {
 
 export const setupGame = async () => {
   try {
-    // if (!stateManager.state?.players || !stateManager.state?.matchId) {
-    //   SPA.navigate("/");
-    //   return
-    // }
+    if (!stateManager.state?.players || !stateManager.state?.matchId) {
+      SPA.navigate("/");
+      return
+    }
     const names = await Promise.all(stateManager.state.players.map(async (id) => await fetchUsername(id)));
     gameRender.renderPlayerNames(names);
     WsConnectionManager.connect(stateManager.state.matchId);

--- a/spa/views/Game.js
+++ b/spa/views/Game.js
@@ -166,7 +166,8 @@ const fetchUsername = async (userid) => {
   if (!res.ok) {
     throw new Error(`failed to fetch user data: ${res.status}`);
   }
-  return await res.json().username;
+  const data = await res.json();
+  return data.username;
 };
 
 export const setupGame = async () => {
@@ -177,7 +178,6 @@ export const setupGame = async () => {
     }
     gameRender.renderGame();
     const names = await Promise.all(stateManager.state.players.map(async (id) => await fetchUsername(id)));
-    console.log(names);
     gameRender.renderPlayerNames(names);
     WsConnectionManager.connect(stateManager.state.matchId);
     PlayerActionHandler.registerEventHandler();

--- a/spa/views/Game.js
+++ b/spa/views/Game.js
@@ -35,7 +35,8 @@ export default function Game() {
         </div>
       </div>
       <h1 class="game-timer display-3 js-game-timer p-0 m-0">60</h1>
-      <h1 class="js-game-error display-3 text-center text-danger fw-bold m-5">Error happend</h1>
+      <h1 class="js-game-error fs-1 text-center text-danger fw-bold text-wrap">Error occured.</h1>
+      <p class="js-game-error-detail fs-2 text-center text-danger text-wrap"></p>
     </div>
     `;
   }
@@ -145,6 +146,16 @@ export const gameRender = {
       }
     });
   },
+  renderError(errMessage) {
+    const errEle = document.querySelector(".js-game-error");
+    const errDetail = document.querySelector(".js-game-error-detail");
+    if (errEle) {
+      errEle.textContent = "Error occured.";
+    }
+    if (errDetail) {
+      errDetail.textContent = errMessage;
+    }
+  }
 };
 
 const fetchUsername = async (userid) => {
@@ -157,10 +168,10 @@ const fetchUsername = async (userid) => {
 
 export const setupGame = async () => {
   try {
-    if (!stateManager.state?.players || !stateManager.state?.matchId) {
-      SPA.navigate("/");
-      return
-    }
+    // if (!stateManager.state?.players || !stateManager.state?.matchId) {
+    //   SPA.navigate("/");
+    //   return
+    // }
     const names = await Promise.all(stateManager.state.players.map(async (id) => await fetchUsername(id)));
     gameRender.renderPlayerNames(names);
     WsConnectionManager.connect(stateManager.state.matchId);
@@ -168,5 +179,6 @@ export const setupGame = async () => {
     gameRender.renderGame();
   } catch (error) {
     console.error(error);
+    gameRender.renderError("failed to setup game.");
   }
 };

--- a/spa/views/Game.js
+++ b/spa/views/Game.js
@@ -172,11 +172,11 @@ export const setupGame = async () => {
       SPA.navigate("/");
       return
     }
+    gameRender.renderGame();
     const names = await Promise.all(stateManager.state.players.map(async (id) => await fetchUsername(id)));
     gameRender.renderPlayerNames(names);
     WsConnectionManager.connect(stateManager.state.matchId);
     PlayerActionHandler.registerEventHandler();
-    gameRender.renderGame();
   } catch (error) {
     console.error(error);
     gameRender.renderError("failed to setup game.");

--- a/spa/views/Game.js
+++ b/spa/views/Game.js
@@ -1,5 +1,6 @@
 import config from "../config.js";
 import PlayerActionHandler from "../services/game/PlayerActionHandler.js";
+import stateManager from "../stateManager.js";
 
 const GAME_HEIGHT = 500;
 const GAME_WIDTH = 800;
@@ -129,7 +130,7 @@ export const gameRender = {
     timerEle.textContent = time;
   },
   renderPlayerNames(players = []) {
-    const nameClasses = [".js-left-player", ".js-left-player"];
+    const nameClasses = [".js-left-player", ".js-right-player"];
     nameClasses.forEach((nameClass, index) => {
       const player = players[index];
       const element = document.querySelector(nameClass);
@@ -137,7 +138,7 @@ export const gameRender = {
       if (element && player) {
         element.textContent = player.name;
       } else if (element) {
-        element.textContent = "player";
+        element.textContent = "";
       }
     });
   },
@@ -153,17 +154,7 @@ const fetchUsername = async (userid) => {
 
 export const setupGame = async () => {
   try {
-    // TODO apiを叩くので一旦実行しない
-    // const matchId = 1;
-    // const res = await fetch(`${config.matchService}/matches?matchId=${matchId}`);
-    // if (!res.ok) {
-    //   throw new Error(`failed to fetch match data: ${res.status}`);
-    // }
-    // const match = await res.json().results[0];
-    // const ids = match.participants.map((player) => player.id);
-    // const gamePlayers = await Promise.all(ids.map(async (id) => await fetchUsername(id)));
-    // gameRender.renderPlayerNames(gamePlayers);
-
+    gameRender.renderPlayerNames(stateManager.state?.players);
     PlayerActionHandler.registerEventHandler();
     gameRender.renderGame();
   } catch (error) {

--- a/spa/views/Game.js
+++ b/spa/views/Game.js
@@ -160,6 +160,8 @@ export const gameRender = {
 };
 
 const fetchUsername = async (userid) => {
+  // TODO: queryをuseridに変更する
+  // userサービスの修正が適応され次第対応
   const res = await fetch(`${config.userService}/users?userId=${userid}`);
   if (!res.ok) {
     throw new Error(`failed to fetch user data: ${res.status}`);
@@ -176,7 +178,6 @@ export const setupGame = async () => {
     }
     gameRender.renderGame();
     const names = await Promise.all(stateManager.state.players.map(fetchUsername));
-    console.log(names)
     gameRender.renderPlayerNames(names);
     WsConnectionManager.connect(stateManager.state.matchId);
     PlayerActionHandler.registerEventHandler();

--- a/spa/views/Game.js
+++ b/spa/views/Game.js
@@ -71,7 +71,9 @@ export const gameRender = {
     const canvas = document.querySelector(".game-canvas");
     const ctx = canvas.getContext("2d");
 
-    const centerX = canvas.width / 2;
+    // 背景クリア
+    ctx.fillStyle = "black";
+    ctx.fillRect(0, 0, GAME_WIDTH, GAME_HEIGHT);
 
     ctx.setLineDash([15, 5]); // 5pxの線と5pxの間隔の点線
     ctx.lineWidth = 2; // 線の太さ
@@ -79,6 +81,7 @@ export const gameRender = {
 
     // 垂直線を描画
     ctx.beginPath();
+    const centerX = canvas.width / 2;
     ctx.moveTo(centerX, 0);
     ctx.lineTo(centerX, canvas.height);
     ctx.stroke();
@@ -174,6 +177,7 @@ export const setupGame = async () => {
     }
     gameRender.renderGame();
     const names = await Promise.all(stateManager.state.players.map(async (id) => await fetchUsername(id)));
+    console.log(names);
     gameRender.renderPlayerNames(names);
     WsConnectionManager.connect(stateManager.state.matchId);
     PlayerActionHandler.registerEventHandler();

--- a/spa/views/GameResult.js
+++ b/spa/views/GameResult.js
@@ -20,3 +20,11 @@ export default function GameResult(params) {
     </div>
   `;
 }
+
+export function setupGameResult() {
+  const homeButtonEle = document.querySelector(".game-result-button");
+  homeButtonEle.addEventListener("click", (event) => {
+    event.preventDefault();
+    SPA.navigate("/", null, true);
+  })
+}

--- a/spa/views/GameResult.js
+++ b/spa/views/GameResult.js
@@ -1,18 +1,20 @@
-export default function GameResult() {
-  const message = {
-    win: "YOU WIN",
-    lose: "YOU LOSE",
-  };
+import SPA from "../spa.js";
+
+export default function GameResult(params) {
+  if (!params) {
+    return SPA.navigate("/", null, true);
+  }
+  const message = params.win ? "YOU WIN" : "YOU LOSE";
   return `
     <div class="game-result-container text-center vh-100">
       <div class="wl-container my-5">
-        <h1 class="game-win-lose wl-first">YOU WIN</h1>
-        <h1 class="game-win-lose wl-second">YOU WIN</h1>
-        <h1 class="game-win-lose wl-third">YOU WIN</h1>
+        <h1 class="game-win-lose wl-first">${message}</h1>
+        <h1 class="game-win-lose wl-second">${message}</h1>
+        <h1 class="game-win-lose wl-third">${message}</h1>
       </div>
       <div class="game-result d-flex justify-content-between w-100 mb-5 py-1">
-        <div class="w-50 text-end game-result-left-player-bgc px-5">12</div>
-        <div class="w-50 text-start game-result-right-player-bgc px-5">0</div>
+        <div class="w-50 text-end game-result-left-player-bgc px-5">${params.left}</div>
+        <div class="w-50 text-start game-result-right-player-bgc px-5">${params.right}</div>
       </div>
       <button type="button" class="my-5 py-3 px-5 game-result-button">Back To Home</button>
     </div>

--- a/spa/views/GameResult.js
+++ b/spa/views/GameResult.js
@@ -21,7 +21,7 @@ export default function GameResult(params) {
   `;
 }
 
-export function setupGameResult() {
+export async function setupGameResult() {
   const homeButtonEle = document.querySelector(".game-result-button");
   homeButtonEle.addEventListener("click", (event) => {
     event.preventDefault();

--- a/spa/views/Home.js
+++ b/spa/views/Home.js
@@ -12,6 +12,8 @@ export default function Home() {
         <button onclick="SPA.navigate('/404')">404へ</button>
         <button onclick="SPA.navigate('/signup')">signupへ</button>
         <button onclick="SPA.navigate('/login')">loginへ</button>
+        <button onclick="SPA.navigate('/game')">gameへ</button>
+        <button onclick="SPA.navigate('/game/setup')">setupgameへ</button>
         ${Footer({ text: "© 2025 My Company" })}
         <div> store sample</div>
         ${stateManager.state.count}

--- a/spa/views/Home.js
+++ b/spa/views/Home.js
@@ -14,6 +14,7 @@ export default function Home() {
         <button onclick="SPA.navigate('/login')">loginへ</button>
         <button onclick="SPA.navigate('/game')">gameへ</button>
         <button onclick="SPA.navigate('/game/setup')">setupgameへ</button>
+        <button onclick="SPA.navigate('/game/result')">gameresultへ</button>
         ${Footer({ text: "© 2025 My Company" })}
         <div> store sample</div>
         ${stateManager.state.count}

--- a/spa/views/InitMatch.js
+++ b/spa/views/InitMatch.js
@@ -37,12 +37,15 @@ export function setupInitMatch() {
       alert("全てのフィールドを入力してください。");
       return;
     }
-    await fetch(`${config.gameService}/games, {
-      method: POST,
+    res = await fetch(`${config.gameService}/games`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
       body: JSON.stringfy({
         matchId: matchId,
         userIdList: [leftPlayerId, rightPlayerId],
-      })
+      }),
     });
     stateManager.setState({ matchId: matchId });
     stateManager.setState({ players: [leftPlayerId, rightPlayerId] });

--- a/spa/views/InitMatch.js
+++ b/spa/views/InitMatch.js
@@ -1,3 +1,4 @@
+import SPA from "../spa.js";
 import stateManager from "../stateManager.js";
 
 // TODO 一旦開発用に仮に作った
@@ -28,14 +29,16 @@ export default function InitMatch() {
 export function setupInitMatch() {
   const formEle = document.querySelector(".js-match-form");
   formEle.addEventListener("submit", (event) => {
-    const matchId = event.target.matchId;
-    const leftPlayerId = event.target.leftPlayerId;
-    const rightPlayerId = event.target.rightPlayerId;
+    const matchId = event.target.matchId.value;
+    const leftPlayerId = event.target.leftPlayerId.value;
+    const rightPlayerId = event.target.rightPlayerId.value;
     if (!matchId || !leftPlayerId || !rightPlayerId) {
       alert("全てのフィールドを入力してください。");
       return;
     }
+    console.log(matchId, leftPlayerId, rightPlayerId);
     stateManager.setState({ matchId: matchId });
     stateManager.setState({ players: [leftPlayerId, rightPlayerId] });
+    SPA.navigate("/game");
   });
 }

--- a/spa/views/InitMatch.js
+++ b/spa/views/InitMatch.js
@@ -1,0 +1,41 @@
+import stateManager from "../stateManager.js";
+
+// TODO 一旦開発用に仮に作った
+export default function InitMatch() {
+  alert(`your userid: ${stateManager?.userId}`);
+  return `
+    <div class="container mt-5">
+      <h2 class="mb-4">試合情報入力フォーム</h2>
+      <form class="js-match-form">
+          <div class="mb-3">
+              <label for="matchId" class="form-label">Match ID</label>
+              <input type="text" class="form-control" id="matchId" name="matchId" placeholder="試合IDを入力">
+          </div>
+          <div class="mb-3">
+              <label for="leftPlayerId" class="form-label">Left Player ID</label>
+              <input type="text" class="form-control" id="leftPlayerId" name="leftPlayerId" placeholder="左プレイヤーIDを入力">
+          </div>
+          <div class="mb-3">
+              <label for="rightPlayerId" class="form-label">Right Player ID</label>
+              <input type="text" class="form-control" id="rightPlayerId" name="rightPlayerId" placeholder="右プレイヤーIDを入力">
+          </div>
+          <button type="submit" class="btn btn-primary">送信</button>
+      </form>
+    </div>
+  `
+};
+
+export function setupInitMatch() {
+  const formEle = document.querySelector(".js-match-form");
+  formEle.addEventListener("submit", (event) => {
+    const matchId = event.target.matchId;
+    const leftPlayerId = event.target.leftPlayerId;
+    const rightPlayerId = event.target.rightPlayerId;
+    if (!matchId || !leftPlayerId || !rightPlayerId) {
+      alert("全てのフィールドを入力してください。");
+      return;
+    }
+    stateManager.setState({ matchId: matchId });
+    stateManager.setState({ players: [leftPlayerId, rightPlayerId] });
+  });
+}

--- a/spa/views/InitMatch.js
+++ b/spa/views/InitMatch.js
@@ -30,6 +30,7 @@ export default function InitMatch() {
 export function setupInitMatch() {
   const formEle = document.querySelector(".js-match-form");
   formEle.addEventListener("submit", async (event) => {
+    event.preventDefault();
     const matchId = event.target.matchId.value;
     const leftPlayerId = event.target.leftPlayerId.value;
     const rightPlayerId = event.target.rightPlayerId.value;
@@ -37,18 +38,22 @@ export function setupInitMatch() {
       alert("全てのフィールドを入力してください。");
       return;
     }
-    res = await fetch(`${config.gameService}/games`, {
+    const res = await fetch(`${config.gameService}/games`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringfy({
+      body: JSON.stringify({
         matchId: matchId,
         userIdList: [leftPlayerId, rightPlayerId],
       }),
     });
     stateManager.setState({ matchId: matchId });
     stateManager.setState({ players: [leftPlayerId, rightPlayerId] });
+    if (res.status >= 400) {
+      console.error(`error status: ${res.status}`);
+      return
+    }
     SPA.navigate("/game");
   });
 }

--- a/spa/views/InitMatch.js
+++ b/spa/views/InitMatch.js
@@ -3,7 +3,7 @@ import stateManager from "../stateManager.js";
 
 // TODO 一旦開発用に仮に作った
 export default function InitMatch() {
-  alert(`your userid: ${stateManager?.userId}`);
+  alert(`your userid: ${stateManager.state?.userId}`);
   return `
     <div class="container mt-5">
       <h2 class="mb-4">試合情報入力フォーム</h2>

--- a/spa/views/InitMatch.js
+++ b/spa/views/InitMatch.js
@@ -1,3 +1,4 @@
+import config from "../config.js";
 import SPA from "../spa.js";
 import stateManager from "../stateManager.js";
 
@@ -28,7 +29,7 @@ export default function InitMatch() {
 
 export function setupInitMatch() {
   const formEle = document.querySelector(".js-match-form");
-  formEle.addEventListener("submit", (event) => {
+  formEle.addEventListener("submit", async (event) => {
     const matchId = event.target.matchId.value;
     const leftPlayerId = event.target.leftPlayerId.value;
     const rightPlayerId = event.target.rightPlayerId.value;
@@ -36,7 +37,13 @@ export function setupInitMatch() {
       alert("全てのフィールドを入力してください。");
       return;
     }
-    console.log(matchId, leftPlayerId, rightPlayerId);
+    await fetch(`${config.gameService}/games, {
+      method: POST,
+      body: JSON.stringfy({
+        matchId: matchId,
+        userIdList: [leftPlayerId, rightPlayerId],
+      })
+    });
     stateManager.setState({ matchId: matchId });
     stateManager.setState({ players: [leftPlayerId, rightPlayerId] });
     SPA.navigate("/game");


### PR DESCRIPTION
## 概要
<!--対応内容-->
- フロントでピンポンゲームができるようになりました
- ゲーム結果画面も表示されます
- 仮のsetupgameページを作成していますが、開発ようの仮ページです


## 関連するチケット
<!--関連するissueやドキュメントなど-->
<!--close #issue number-->
close #131 


## レビューしてほしい点
<!--特に気をつけてレビューして欲しい点があれば-->


## 動作確認方法
<!--共有しないといけない点があれば-->
makeですべてのサービスを起動する
signupページでユーザーを二人作成（それぞれのタブでユーザーを作成）
ユーザーが作成できたらホーム画面にもどる（戻るボタンでもどる、urlを直接触ってはだめ！stateが消えてしまうため）
setupgameページに移動してgameの情報を登録する（各ユーザーそれぞれで登録すること、2人目のユーザーはゲームページに自動でとばないので、戻るボタンでホームに戻り、ゲームページに飛ぶ）
二人のユーザがゲームページに遷移するとゲームが開始する

**WARN**
pageを遷移するときに、urlを直接触ってはだめ！
stateが消えてしまうため

