### PR TITLE
Issue142 incorporate jwt into match rikeda

### DIFF
--- a/match_service/match_app/jwt_decorators.py
+++ b/match_service/match_app/jwt_decorators.py
@@ -1,0 +1,28 @@
+from functools import wraps
+
+import jwt
+from rest_framework.response import Response
+
+
+def jwt_required(func):
+    @wraps(func)
+    def wrapper(request, *args, **kwargs):
+        token = request.COOKIES.get("access_token")
+        if not token:
+            return Response({"error": "Access token missing"}, status=401)
+
+        try:
+            # TODO 署名検証なしでデコード
+            decoded_token = jwt.decode(token, options={"verify_signature": False})
+
+            request.user_id = decoded_token.get("user_id")  # user_id をリクエストに保存
+
+            return func(request, *args, **kwargs)
+
+        except jwt.ExpiredSignatureError:
+            return Response({"error": "Token expired"}, status=401)
+        except jwt.InvalidTokenError:
+            return Response({"error": "Invalid token"}, status=401)
+        # request.user_id = 1
+
+    return wrapper

--- a/match_service/match_app/tests/test_match_history_view.py
+++ b/match_service/match_app/tests/test_match_history_view.py
@@ -1,3 +1,4 @@
+import jwt
 import pytest
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 
@@ -12,6 +13,11 @@ class TestMatchHistory:
         client, status, user_id, expect_total, expect_limit, offset=None, limit=None
     ) -> dict:
         query_string = create_query_string(offset=offset, limit=limit)
+
+        token_payload = {"user_id": 1}
+        token = jwt.encode(token_payload, "secret_key", algorithm="HS256")
+        client.cookies["access_token"] = token
+
         response = client.get(f"/matches/histories/{user_id}{query_string}")
         assert response.status_code == status
 

--- a/match_service/match_app/tests/test_match_statistics_view.py
+++ b/match_service/match_app/tests/test_match_statistics_view.py
@@ -1,3 +1,4 @@
+import jwt
 import pytest
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 
@@ -6,6 +7,10 @@ from match_app.models import Match, MatchParticipant
 
 class TestMatchStatistics:
     def request_match_statistics(self, client, status, user_id):
+        token_payload = {"user_id": 1}
+        token = jwt.encode(token_payload, "secret_key", algorithm="HS256")
+        client.cookies["access_token"] = token
+
         response = client.get(f"/matches/statistics/{user_id}")
         assert response.status_code == status
         return response.json()

--- a/match_service/match_app/tests/test_match_view.py
+++ b/match_service/match_app/tests/test_match_view.py
@@ -1,3 +1,4 @@
+import jwt
 import pytest
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 
@@ -37,6 +38,12 @@ class TestMatchView:
             offset=offset,
             limit=limit,
         )
+
+        #  Cookieに適当なuser_idのJWTを付与する
+        token_payload = {"user_id": 1}
+        token = jwt.encode(token_payload, "secret_key", algorithm="HS256")
+        client.cookies["access_token"] = token
+
         response = client.get(f"/matches{query_string}")
 
         assert response.status_code == status

--- a/match_service/match_app/views/match_history_view.py
+++ b/match_service/match_app/views/match_history_view.py
@@ -1,10 +1,10 @@
+from django.utils.decorators import method_decorator
+from match_app.jwt_decorators import jwt_required
 from match_app.models import Match, MatchParticipant
 from match_app.serializers import MatchHistorySerializer, UserIdValidator
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from rest_framework.views import APIView
-from django.utils.decorators import method_decorator
-from match_app.jwt_decorators import jwt_required
 
 
 class MatchHistoryView(APIView):

--- a/match_service/match_app/views/match_history_view.py
+++ b/match_service/match_app/views/match_history_view.py
@@ -3,11 +3,14 @@ from match_app.serializers import MatchHistorySerializer, UserIdValidator
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from rest_framework.views import APIView
+from django.utils.decorators import method_decorator
+from match_app.jwt_decorators import jwt_required
 
 
 class MatchHistoryView(APIView):
     """user_idに対応する試合履歴情報を取得する"""
 
+    @method_decorator(jwt_required)
     def get(self, request, user_id):
         serializer = MatchHistorySerializer(data=request.query_params)
         user_id_validator = UserIdValidator(data={"user_id": user_id})

--- a/match_service/match_app/views/match_statistic_view.py
+++ b/match_service/match_app/views/match_statistic_view.py
@@ -1,10 +1,10 @@
+from django.utils.decorators import method_decorator
+from match_app.jwt_decorators import jwt_required
 from match_app.models import Match, MatchParticipant
 from match_app.serializers import UserIdValidator
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from rest_framework.views import APIView
-from django.utils.decorators import method_decorator
-from match_app.jwt_decorators import jwt_required
 
 
 class MatchStatisticView(APIView):

--- a/match_service/match_app/views/match_statistic_view.py
+++ b/match_service/match_app/views/match_statistic_view.py
@@ -3,11 +3,14 @@ from match_app.serializers import UserIdValidator
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from rest_framework.views import APIView
+from django.utils.decorators import method_decorator
+from match_app.jwt_decorators import jwt_required
 
 
 class MatchStatisticView(APIView):
     """user_idに対応する統計情報を取得する"""
 
+    @method_decorator(jwt_required)
     def get(self, _, user_id):
         user_id_validator = UserIdValidator(data={"user_id": user_id})
         if not user_id_validator.is_valid():

--- a/match_service/match_app/views/match_view.py
+++ b/match_service/match_app/views/match_view.py
@@ -3,11 +3,14 @@ from match_app.serializers import MatchSerializer
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from rest_framework.views import APIView
+from django.utils.decorators import method_decorator
+from match_app.jwt_decorators import jwt_required
 
 
 class MatchView(APIView):
     """QueryStringに指定された条件を用いてMatchを検索"""
 
+    @method_decorator(jwt_required)
     def get(self, request):
         serializer = MatchSerializer(data=request.query_params)
         if not serializer.is_valid():

--- a/match_service/match_app/views/match_view.py
+++ b/match_service/match_app/views/match_view.py
@@ -1,10 +1,10 @@
+from django.utils.decorators import method_decorator
+from match_app.jwt_decorators import jwt_required
 from match_app.models import Match, MatchParticipant
 from match_app.serializers import MatchSerializer
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from rest_framework.views import APIView
-from django.utils.decorators import method_decorator
-from match_app.jwt_decorators import jwt_required
 
 
 class MatchView(APIView):


### PR DESCRIPTION
## 概要
<!--対応内容-->
* `/matches/`エンドポイントへのJWT処理の組み込み
* `/matches/statistics`エンドポイントへのJWT処理の組み込み
* `/matches/histories`エンドポイントへのJWT処理の組み込み
* JWT処理の組み込みに伴うテストの修正


## 関連するチケット
<!--関連するissueやドキュメントなど-->
<!--close #issue number-->
close #142 


## レビューしてほしい点
<!--特に気をつけてレビューして欲しい点があれば-->
* WebSocket用エンドポイントは既にJWT処理が組み込まれています。
* `/matches/tournament-match`と`/matches/finish`はJWTではなく、APIキーを用いて認証するので何もしていません。
* View内でuser_idを使用するようなエンドポイントは無いので、テストのuser_idには適当な値を入れています。

## 動作確認方法
<!--共有しないといけない点があれば-->
* テストのみです。
