### PR TITLE
[fix] WAFで弾かれるメソッドを許可するような設定を追加

### DIFF
--- a/waf_proxy_service/Dockerfile
+++ b/waf_proxy_service/Dockerfile
@@ -10,5 +10,6 @@ COPY nginx/conf.d/default.conf.template /etc/nginx/templates/conf.d/
 COPY nginx/includes/ /etc/nginx/templates/includes/
 
 COPY modsecurity.d/ /etc/nginx/templates/modsecurity.d/
+COPY ./modsecurity.d/REQUEST-911-METHOD-ENFORCEMENT.conf /etc/modsecurity.d/owasp-crs/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/waf_proxy_service/modsecurity.d/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/waf_proxy_service/modsecurity.d/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -1,0 +1,77 @@
+# ------------------------------------------------------------------------
+# OWASP CRS ver.4.11.0
+# Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
+# Copyright (c) 2021-2025 CRS project. All rights reserved.
+#
+# The OWASP CRS is distributed under
+# Apache Software License (ASL) version 2
+# Please see the enclosed LICENSE file for full details.
+# ------------------------------------------------------------------------
+
+#
+# -= Paranoia Level 0 (empty) =- (apply unconditionally)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.11.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.11.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+#
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
+#
+
+#
+# -=[ Allowed Request Methods ]=-
+#
+# tx.allowed_methods is defined in the crs-setup.conf file
+#
+# INFO この箇所を使用するすべてのメソッドを許可するようにカスタム設定
+SecRule REQUEST_METHOD "!@within GET HEAD POST OPTIONS PUT DELETE PATCH" \
+    "id:911100,\
+    phase:1,\
+    block,\
+    msg:'Method is not allowed by policy',\
+    logdata:'%{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-generic',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/210/272/220/274',\
+    tag:'PCI/12.1',\
+    ver:'OWASP_CRS/4.11.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.11.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.11.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+#
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.11.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.11.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+#
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.11.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.11.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+#
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
+#
+
+
+
+#
+# -= Paranoia Levels Finished =-
+#
+SecMarker "END-REQUEST-911-METHOD-ENFORCEMENT"

--- a/waf_proxy_service/modsecurity.d/modsecurity.conf.template
+++ b/waf_proxy_service/modsecurity.d/modsecurity.conf.template
@@ -252,7 +252,7 @@ SecAuditLogParts ABIJDEFHZ
 # assumes that you will use the audit log only ocassionally.
 #
 SecAuditLogType Serial
-SecAuditLog /var/log/modsec_audit.log
+SecAuditLog /var/log/nginx/error.log
 
 # Specify the path for concurrent audit logging.
 #SecAuditLogStorageDir /opt/modsecurity/var/audit/


### PR DESCRIPTION
## 概要
<!--対応内容-->
* WAFで403が返る原因究明と修正

## 関連するチケット
<!--関連するissueやドキュメントなど-->
<!--close #issue number-->
close #214 

## 動作確認方法
<!--共有しないといけない点があれば-->
* usernameの更新、avatarのEditとDeleteは実行できました。
* [modsecurityのデフォルト設定](https://github.com/coreruleset/modsecurity-crs-docker?tab=readme-ov-file#crs-specific)で`ALLOWED_METHODS`がデフォルトで`GET HEAD POST OPTIONS`メソッドしか許可していないのが原因のようだったので、`PUT DELETE PATCH`も許可するように設定を追加しました。