### PR TITLE
[fix] profileのifブロックを変更

### DIFF
--- a/spa/views/Profile.js
+++ b/spa/views/Profile.js
@@ -88,26 +88,25 @@ export async function setupProfile() {
       stateManager.state.username;
     document.querySelector(".js-user-avatar").src =
       stateManager.state.avatarUrl;
-    return;
+  } else {
+    const { status: uStatus, data: uData } = await fetchApiNoBody(
+      "GET",
+      config.userService,
+      `/users?userid=${stateManager.state.userId}`,
+    );
+
+    if (uStatus === null || uStatus >= 400) {
+      console.error("ユーザー情報の取得に失敗しました");
+    } else {
+      const avatarUrl = `${config.userService}${uData.avatarPath}`;
+
+      document.querySelector(".js-username").textContent = uData.username;
+      document.querySelector(".js-user-avatar").src = avatarUrl;
+
+      stateManager.setState({ username: uData.username });
+      stateManager.setState({ avatarUrl: avatarUrl });
+    }
   }
-
-  const { status: uStatus, data: uData } = await fetchApiNoBody(
-    "GET",
-    config.userService,
-    `/users?userid=${stateManager.state.userId}`,
-  );
-
-  if (uStatus === null || uStatus >= 400) {
-    console.error("ユーザー情報の取得に失敗しました");
-    return;
-  }
-  const avatarUrl = `${config.userService}${uData.avatarPath}`;
-
-  document.querySelector(".js-username").textContent = uData.username;
-  document.querySelector(".js-user-avatar").src = avatarUrl;
-
-  stateManager.setState({ username: uData.username });
-  stateManager.setState({ avatarUrl: avatarUrl });
 
   if (!stateManager.state.userId) {
     return;


### PR DESCRIPTION
## 概要
<!--対応内容-->
profile画面で２回目以降(キャッシュがあるとき)に試合統計のapiを叩かずreturnしていたので修正しました。

## 関連するチケット
<!--関連するissueやドキュメントなど-->
<!--close #issue number-->


## レビューしてほしい点
<!--特に気をつけてレビューして欲しい点があれば-->


## 動作確認方法
<!--共有しないといけない点があれば-->
-profileを２回め以降に叩いても試合統計が表示される(loading..ではなく数字が表示される)

## 参考文献
<!--共有すべき参考文献があれば-->


## 備考

