### PR TITLE
Issue56 websocket design rikeda

### DIFF
--- a/docs/ws_quick_play_matching.yaml
+++ b/docs/ws_quick_play_matching.yaml
@@ -1,0 +1,47 @@
+asyncapi: 3.0.0
+info:
+  title: QuickPlay Matching
+  version: 1.0.0
+  description: |
+    QuickPlayモードのマッチング用WebSocketエンドポイント。
+    参加者が揃い次第`match_id`が返される。
+
+servers:
+  production:
+    host: match.transcen.com
+    pathname: /matches/ws/enter-room
+    protocol: wss
+    description: matchサービス用APIサーバ
+
+channels:
+  quickPlayMatching:
+    description: QuickPlayモードのマッチングルーム
+    messages:
+      matchStart:
+        $ref: '#/components/messages/MatchStartNotification'
+
+operations:
+  receiveMatchStart:
+    action: 'receive'
+    channel:
+      $ref: '#/channels/quickPlayMatching'
+
+components:
+  messages:
+    MatchStartNotification:
+      summary: サーバからの試合開始通知
+      payload:
+        type: object
+        properties:
+          match_id:
+            type: string
+            nullable: true
+            description: |
+              マッチング成功時は試合ID、
+              内部エラー時は文字列で`None`、
+              マッチング中はmatch_idは含まれない
+          user_id_list:
+            type: array
+            items:
+              type: integer
+            description: マッチングされたユーザーのIDリスト

--- a/docs/ws_quick_play_matching.yaml
+++ b/docs/ws_quick_play_matching.yaml
@@ -21,8 +21,8 @@ channels:
         $ref: '#/components/messages/MatchStartNotification'
 
 operations:
-  receiveMatchStart:
-    action: 'receive'
+  sendMatchStart:
+    action: 'send'
     channel:
       $ref: '#/channels/quickPlayMatching'
 

--- a/docs/ws_tournament.yaml
+++ b/docs/ws_tournament.yaml
@@ -21,13 +21,10 @@ channels:
         $ref: '#/components/messages/TournamentInfo'
 
 operations:
-  finishTournamentMatch:
-    action: 'receive'
+  sendTournamentInfo:
+    action: 'send'
     channel:
       $ref: '#/channels/tournament'
-    summary: |
-      他のAPIサーバからのHTTPリクエストによって
-      トーナメント試合終了イベントが通知される
 
 components:
   messages:

--- a/docs/ws_tournament.yaml
+++ b/docs/ws_tournament.yaml
@@ -1,0 +1,56 @@
+asyncapi: 3.0.0
+info:
+  title: Tournament
+  version: 1.0.0
+  description: |
+    Tournament用WebSocketエンドポイント。
+    トーナメント状況を通知。
+
+servers:
+  production:
+    host: tournament.transcen.com
+    pathname: /tournaments/ws/enter-room/{tournamentId}
+    protocol: wss
+    description: tournamentサービス用APIサーバ
+
+channels:
+  tournament:
+    description: Tournamentのルーム
+    messages:
+      tournamentInfo:
+        $ref: '#/components/messages/TournamentInfo'
+
+operations:
+  finishTournamentMatch:
+    action: 'receive'
+    channel:
+      $ref: '#/channels/tournament'
+    summary: |
+      他のAPIサーバからのHTTPリクエストによって
+      トーナメント試合終了イベントが通知される
+
+components:
+  messages:
+    TournamentInfo:
+      summary: サーバからのトーナメント情報の通知
+      payload:
+        type: object
+        properties:
+          matches_data:
+            type: array
+            items: 
+              type: object
+              additionalProperties: true
+            description: |
+              トーナメントの全ての試合の情報。
+              ソートはされていない。
+          current_round:
+            type: integer
+            description: 現在のトーナメント試合のラウンド
+          state:
+            type: string
+            enum: 
+              - ongoing
+              - error
+              - finished
+            description: 現在の試合の状況

--- a/docs/ws_tournament_match.yaml
+++ b/docs/ws_tournament_match.yaml
@@ -21,8 +21,8 @@ channels:
         $ref: '#/components/messages/TournamentMatchStartNotification'
 
 operations:
-  enterParticipant:
-    action: 'receive'
+  sendTournamentMatchInfo:
+    action: 'send'
     channel:
       $ref: '#/channels/tournamentMatchWaitRoom'
 

--- a/docs/ws_tournament_match.yaml
+++ b/docs/ws_tournament_match.yaml
@@ -1,0 +1,45 @@
+asyncapi: 3.0.0
+info:
+  title: Tournament Match
+  version: 1.0.0
+  description: |
+    Tournament試合待機用WebSocketエンドポイント。
+    参加者が揃い次第`match_id`が返される。
+
+servers:
+  production:
+    host: match.transcen.com
+    pathname: /matches/ws/enter-room/{tournamentId}
+    protocol: wss
+    description: matcheサービス用APIサーバ
+
+channels:
+  tournamentMatchWaitRoom:
+    description: Tournament試合の待機ルーム
+    messages:
+      tournamentInfo:
+        $ref: '#/components/messages/TournamentMatchStartNotification'
+
+operations:
+  enterParticipant:
+    action: 'receive'
+    channel:
+      $ref: '#/channels/tournamentMatchWaitRoom'
+
+components:
+  messages:
+    TournamentMatchStartNotification:
+      summary: サーバからのトーナメント試合開始通知
+      payload:
+        type: object
+        properties:
+          match_id:
+            type: string
+            description: |
+              マッチング成功時は試合ID、
+              内部エラー時は文字列で`None`
+          user_id_list:
+            type: array
+            items:
+              type: integer
+            description: マッチングされたユーザーのIDリスト

--- a/docs/ws_tournament_matching.yaml
+++ b/docs/ws_tournament_matching.yaml
@@ -21,8 +21,8 @@ channels:
         $ref: '#/components/messages/TournamentStartNotification'
 
 operations:
-  receiveTournamentStart:
-    action: 'receive'
+  sendTournamentStart:
+    action: 'send'
     channel:
       $ref: '#/channels/tournamentMatching'
 

--- a/docs/ws_tournament_matching.yaml
+++ b/docs/ws_tournament_matching.yaml
@@ -1,0 +1,54 @@
+asyncapi: 3.0.0
+info:
+  title: Tournament Matching
+  version: 1.0.0
+  description: |
+    Tournamentモードのマッチング用WebSocketエンドポイント。
+    参加者が揃い次第`tournament_id`が返される。
+
+servers:
+  production:
+    host: tournament.transcen.com
+    pathname: /tournaments/ws/enter-room
+    protocol: wss
+    description: tournamentサービス用APIサーバ
+
+channels:
+  tournamentMatching:
+    description: Tournamentモードのマッチングルーム
+    messages:
+      matchStart:
+        $ref: '#/components/messages/TournamentStartNotification'
+
+operations:
+  receiveTournamentStart:
+    action: 'receive'
+    channel:
+      $ref: '#/channels/tournamentMatching'
+
+components:
+  messages:
+    TournamentStartNotification:
+      summary: サーバからのトーナメント開始通知
+      payload:
+        type: object
+        properties:
+          tournament_id:
+            type: string
+            nullable: true
+            description: |
+              マッチング成功時はトーナメントID、
+              内部エラー時は文字列で`None`、
+              マッチング中はtournament_idは含まれない
+          tournament_start_time:
+            type: string
+            description: |
+              トーナメント開始時刻のUNIXタイムスタンプ
+          wait_user_ids:
+            type: array
+            items:
+              type: integer
+            description: マッチングされたユーザーのIDリスト
+          room_capacity:
+            type: integer
+            description: Tournamentの最大参加人数


### PR DESCRIPTION
## 概要
<!--対応内容-->
* `QuickPlayMatching`, `TournamentMatching`, `TournamentMatchWait`, `Tournament`のWebSocketエンドポイント用の設計書を作成しました。


## 関連するチケット
<!--関連するissueやドキュメントなど-->
<!--close #issue number-->
close #56 

## 動作確認方法
<!--共有しないといけない点があれば-->
* [AsyncAPI Studio](https://studio.asyncapi.com)に設計書の内容をコピペすると見れます。