### PR TITLE
Issue260 fix form reload rikeda

### DIFF
--- a/spa/spa.js
+++ b/spa/spa.js
@@ -39,9 +39,20 @@ const SPA = (() => {
       // INFO setupよりも先にcurrentRouteを更新する必要有り
       currentRoute = route;
       container.innerHTML = route.view(params);
+      cancelFormDefaultEventIfExist();
       if (route.setup) {
         await route.setup();
       }
+    }
+  };
+
+  const cancelFormDefaultEventIfExist = () => {
+    // WARN 1ページに複数のform要素がある場合は別途処理が必要
+    const form = document.querySelector("form");
+    if (form) {
+      form.addEventListener("submit", (e) => {
+        e.preventDefault();
+      });
     }
   };
 

--- a/spa/spa.js
+++ b/spa/spa.js
@@ -39,17 +39,16 @@ const SPA = (() => {
       // INFO setupよりも先にcurrentRouteを更新する必要有り
       currentRoute = route;
       container.innerHTML = route.view(params);
-      cancelFormDefaultEventIfExist();
+      cancelFormDefaultEvent();
       if (route.setup) {
         await route.setup();
       }
     }
   };
 
-  const cancelFormDefaultEventIfExist = () => {
-    // WARN 1ページに複数のform要素がある場合は別途処理が必要
-    const form = document.querySelector("form");
-    if (form) {
+  const cancelFormDefaultEvent = () => {
+    const forms = document.querySelectorAll("form");
+    for (const form of forms) {
       form.addEventListener("submit", (e) => {
         e.preventDefault();
       });


### PR DESCRIPTION
## 概要
<!--対応内容-->
* Formで入力欄が１つの場合、入力欄でenterを押すとformタグのデフォルトのイベントリスナーが走り、リロードしてしまうバグの修正。

## 関連するチケット
<!--関連するissueやドキュメントなど-->
<!--close #issue number-->
close #260 

## 動作確認方法
<!--共有しないといけない点があれば-->
* `FindFriendForm`や`ChangeEmailForm`など、入力欄が1つのFormでenterを押し、リロードが起こらないか。