### PR TITLE
Issue266 sessionstorage rikeda

### DIFF
--- a/spa/services/tournament/WsTournamentManager.js
+++ b/spa/services/tournament/WsTournamentManager.js
@@ -1,4 +1,5 @@
 import config from "../../config.js";
+import stateManager from "../../stateManager.js";
 import { renderTournamentBracket } from "./TournamentBracket.js";
 import createTournamentData from "./createTournamentData.js";
 import {

--- a/spa/services/tournament/WsTournamentManager.js
+++ b/spa/services/tournament/WsTournamentManager.js
@@ -59,7 +59,7 @@ const wsEventHandler = {
   },
   handleError(message) {
     replaceNeonInfoToBackToHomeButton();
-    stateManager.state.tournamentId = null;
+    stateManager.setState({ tournamentId: null });
     console.error("WebSocket error:", message);
   },
 };

--- a/spa/services/tournament/WsTournamentManager.js
+++ b/spa/services/tournament/WsTournamentManager.js
@@ -5,6 +5,7 @@ import {
   errorStateHandler,
   finishedStateHandler,
   ongoingStateHandler,
+  replaceNeonInfoToBackToHomeButton,
 } from "./tournamentStateHandler.js";
 
 const wsEventHandler = {
@@ -57,6 +58,8 @@ const wsEventHandler = {
     console.log("Disconnected from Tournament room");
   },
   handleError(message) {
+    replaceNeonInfoToBackToHomeButton();
+    stateManager.state.tournamentId = null;
     console.error("WebSocket error:", message);
   },
 };

--- a/spa/services/tournament/tournamentStateHandler.js
+++ b/spa/services/tournament/tournamentStateHandler.js
@@ -58,23 +58,6 @@ export async function finishedStateHandler(matchesData) {
   WsTournamentMatchManager.disconnect();
   return;
 
-  function replaceNeonInfoToBackToHomeButton() {
-    const oldElement = document.getElementById("neon-info");
-    const wrapper = document.createElement("div");
-    wrapper.className = "d-flex justify-content-center";
-
-    const newElement = document.createElement("button");
-    newElement.type = "button";
-    newElement.className = "my-5 py-3 px-5 tournament-result-button";
-    newElement.textContent = "Back To Home";
-    newElement.addEventListener("click", (event) => {
-      event.preventDefault();
-      SPA.navigate("/home", null, true);
-    });
-    wrapper.appendChild(newElement);
-    oldElement.replaceWith(wrapper);
-  }
-
   async function fetchWinnerPlayerName(matchesData) {
     const winnerUserId = matchesData.reduce((latestMatch, currentMatch) => {
       return currentMatch.round > latestMatch.round
@@ -93,4 +76,24 @@ export async function finishedStateHandler(matchesData) {
     }
     return winnerUser.data.username;
   }
+}
+
+export function replaceNeonInfoToBackToHomeButton() {
+  const oldElement = document.getElementById("neon-info");
+  if (!oldElement) {
+    return;
+  }
+  const wrapper = document.createElement("div");
+  wrapper.className = "d-flex justify-content-center";
+
+  const newElement = document.createElement("button");
+  newElement.type = "button";
+  newElement.className = "my-5 py-3 px-5 tournament-result-button";
+  newElement.textContent = "Back To Home";
+  newElement.addEventListener("click", (event) => {
+    event.preventDefault();
+    SPA.navigate("/home", null, true);
+  });
+  wrapper.appendChild(newElement);
+  oldElement.replaceWith(wrapper);
 }

--- a/spa/services/tournament/tournamentStateHandler.js
+++ b/spa/services/tournament/tournamentStateHandler.js
@@ -46,7 +46,7 @@ export async function ongoingStateHandler(matchesData, currentRound) {
 
 export async function errorStateHandler() {
   renderNeonInfo("ERROR", "#FF0000");
-  stateManager.state.tournamentId = null;
+  stateManager.setState({ tournamentId: null });
   console.error("Tournament error");
 }
 
@@ -54,7 +54,7 @@ export async function finishedStateHandler(matchesData) {
   replaceNeonInfoToBackToHomeButton();
   const winnerPlayerName = await fetchWinnerPlayerName(matchesData);
   renderWinnerPlayer(winnerPlayerName);
-  stateManager.state.tournamentId = null;
+  stateManager.setState({ tournamentId: null });
   WsTournamentMatchManager.disconnect();
   return;
 

--- a/spa/stateManager.js
+++ b/spa/stateManager.js
@@ -1,22 +1,51 @@
+// このパラメータのみ、sessionStorageに保存する
+const PERSIST_KEYS = ["tournamentId", "matchId", "players"];
+
 const stateManager = {
   state: {
     userId: null,
     username: null,
     avatarUrl: null,
+    tournamentId: null,
     matchId: null,
     players: null,
     onlineUsers: null,
   },
   listeners: [],
+
+  // 初期化で sessionStorage から復元
+  init() {
+    for (const key of PERSIST_KEYS) {
+      const stored = sessionStorage.getItem(key);
+      if (stored !== null) {
+        try {
+          this.state[key] = JSON.parse(stored);
+        } catch {
+          this.state[key] = stored;
+        }
+      }
+    }
+  },
+
   setState(newState) {
-    this.state = { ...this.state, ...newState };
+    for (const key in newState) {
+      // 特定のパラメータのみsessionStorageに保存する
+      if (PERSIST_KEYS.includes(key)) {
+        sessionStorage.setItem(key, JSON.stringify(newState[key]));
+      }
+      this.state[key] = newState[key];
+    }
+
     for (const listener of this.listeners) {
       listener(this.state);
     }
   },
+
   subscribe(listener) {
     this.listeners.push(listener);
   },
 };
+
+stateManager.init();
 
 export default stateManager;

--- a/spa/views/GameResult.js
+++ b/spa/views/GameResult.js
@@ -7,6 +7,7 @@ export default function GameResult(params) {
     !params ||
     !expectedKeys.every((key) => key in params && params[key] !== undefined)
   ) {
+    stateManager.setState("tournamentId", null);
     return `
       <div class="game-result-container text-center vh-100">
         <button type="button" class="my-5 py-3 px-5 game-result-button">Back To Home</button>

--- a/spa/views/GameResult.js
+++ b/spa/views/GameResult.js
@@ -7,7 +7,7 @@ export default function GameResult(params) {
     !params ||
     !expectedKeys.every((key) => key in params && params[key] !== undefined)
   ) {
-    stateManager.setState("tournamentId", null);
+    stateManager.setState({ tournamentId: null });
     return `
       <div class="game-result-container text-center vh-100">
         <button type="button" class="my-5 py-3 px-5 game-result-button">Back To Home</button>


### PR DESCRIPTION
## 概要
<!--対応内容-->
* `tournamentId`, `matchId`, `players`をsessionStorageに保存するようにSPAフレームワークを修正。
* TournamentのGame画面でリロード後にGameが終了すると、Tournament画面に戻ったときに中途半端な画面が表示されるので、BackToHomeボタンが描画されるように修正。
* リロードしてもGameとTournamentができるようになりました。

## 関連するチケット
<!--関連するissueやドキュメントなど-->
<!--close #issue number-->
close #266 

## レビューしてほしい点
<!--特に気をつけてレビューして欲しい点があれば-->
* 一通り動かしてみましたが、仕様外のことをしているので抜け・漏れ等あると思います。

## 動作確認方法
<!--共有しないといけない点があれば-->
* Tournament画面やTournamentのGame画面でリロードし、正常にサイトが機能するか？