### PR TITLE
Issue257 fix vault reboot rikeda

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - auth_db
       - auth_redis
     env_file: ./docker_env/auth.env
+    restart: always
     volumes:
       - ./certs/client.crt:/certs/client.crt:ro
       - ./certs/client.key:/certs/client.key:ro
@@ -19,6 +20,7 @@ services:
     env_file: ./docker_env/auth_db.env
     networks:
       - app_network
+    restart: always
     volumes:
       - auth_db_data:/var/lib/postgresql/data
 
@@ -27,6 +29,7 @@ services:
     container_name: auth_redis_server
     networks:
       - app_network
+    restart: always
 
   auth_proxy:
     build: ./waf_proxy_service
@@ -54,6 +57,7 @@ services:
       - app_network
     depends_on:
       - game_redis
+    restart: always
     volumes:
       - ./certs/client.crt:/certs/client.crt:ro
       - ./certs/client.key:/certs/client.key:ro
@@ -64,6 +68,7 @@ services:
     container_name: game_redis_server
     networks:
       - app_network
+    restart: always
 
   game_proxy:
     build: ./waf_proxy_service
@@ -92,6 +97,7 @@ services:
     depends_on:
       - tournament_db
       - tournament_redis
+    restart: always
     volumes:
       - ./certs/client.crt:/certs/client.crt:ro
       - ./certs/client.key:/certs/client.key:ro
@@ -103,6 +109,7 @@ services:
     env_file: ./docker_env/tournament_db.env
     networks:
       - app_network
+    restart: always
     volumes:
       - tournament_db_data:/var/lib/postgresql/data
 
@@ -111,6 +118,7 @@ services:
     container_name: tournament_redis
     networks:
       - app_network
+    restart: always
   
   tournament_proxy:
     build: ./waf_proxy_service
@@ -138,6 +146,7 @@ services:
     depends_on:
       - user_db
     env_file: ./docker_env/user.env
+    restart: always
     volumes:
       - user_media:/app/user_app/media/
       - ./certs/client.crt:/certs/client.crt:ro
@@ -150,6 +159,7 @@ services:
     env_file: ./docker_env/user_db.env
     networks:
       - app_network
+    restart: always
     volumes:
       - user_db_data:/var/lib/postgresql/data
 
@@ -179,6 +189,7 @@ services:
     env_file: ./docker_env/friends_activity.env
     networks:
       - app_network
+    restart: always
     volumes:
       - ./certs/client.crt:/certs/client.crt:ro
       - ./certs/client.key:/certs/client.key:ro
@@ -210,6 +221,7 @@ services:
       - app_network
     depends_on:
       - friends_db
+    restart: always
     volumes:
       - ./certs/client.crt:/certs/client.crt:ro
       - ./certs/client.key:/certs/client.key:ro
@@ -221,6 +233,7 @@ services:
     env_file: ./docker_env/friends_db.env
     networks:
       - app_network
+    restart: always
     volumes:
       - friends_db_data:/var/lib/postgresql/data
 
@@ -251,6 +264,7 @@ services:
     depends_on:
       - match_db
       - match_redis
+    restart: always
     volumes:
       - ./certs/client.crt:/certs/client.crt:ro
       - ./certs/client.key:/certs/client.key:ro
@@ -262,6 +276,7 @@ services:
     env_file: ./docker_env/match_db.env
     networks:
       - app_network
+    restart: always
     volumes:
       - match_db_data:/var/lib/postgresql/data
 
@@ -270,6 +285,7 @@ services:
     container_name: match_redis
     networks:
       - app_network
+    restart: always
 
   match_proxy:
     build: ./waf_proxy_service
@@ -296,6 +312,7 @@ services:
     networks:
       - app_network
     env_file: ./docker_env/vault.env
+    restart: always
     volumes:
       - ./certs/client.crt:/vault/certs/client.crt:ro
       - ./certs/client.key:/vault/certs/client.key:ro
@@ -311,6 +328,7 @@ services:
       - "443:443"
     networks:
       - app_network
+    restart: always
     volumes:
       - ./spa:/usr/share/nginx/html:ro
       - ./spa/nginx.conf:/etc/nginx/conf.d/default.conf:ro
@@ -327,6 +345,7 @@ services:
     env_file: ./docker_env/exporter.env
     command:
       - '--nginx.scrape-uri=https://www.transcen.com/nginx_status'
+    restart: always
     volumes:
       - ./certs/ca.crt:/certs/ca.crt:ro
 
@@ -340,6 +359,7 @@ services:
     env_file: ./docker_env/exporter.env
     command:
       - '--nginx.scrape-uri=https://auth-proxy.transcen.com:8005/nginx_status'
+    restart: always
     volumes:
       - ./certs/ca.crt:/certs/ca.crt:ro
 
@@ -353,6 +373,7 @@ services:
     env_file: ./docker_env/exporter.env
     command:
       - '--nginx.scrape-uri=https://game-proxy.transcen.com:8004/nginx_status'
+    restart: always
     volumes:
       - ./certs/ca.crt:/certs/ca.crt:ro
 
@@ -366,6 +387,7 @@ services:
     env_file: ./docker_env/exporter.env
     command:
       - '--nginx.scrape-uri=https://tournament-proxy.transcen.com:8006/nginx_status'
+    restart: always
     volumes:
       - ./certs/ca.crt:/certs/ca.crt:ro
 
@@ -379,6 +401,7 @@ services:
     env_file: ./docker_env/exporter.env
     command:
       - '--nginx.scrape-uri=https://user-proxy.transcen.com:8009/nginx_status'
+    restart: always
     volumes:
       - ./certs/ca.crt:/certs/ca.crt:ro
 
@@ -392,6 +415,7 @@ services:
     env_file: ./docker_env/exporter.env
     command:
       - '--nginx.scrape-uri=https://friends-activity-proxy.transcen.com:10001/nginx_status'
+    restart: always
     volumes:
       - ./certs/ca.crt:/certs/ca.crt:ro
 
@@ -405,6 +429,7 @@ services:
     env_file: ./docker_env/exporter.env
     command:
       - '--nginx.scrape-uri=https://friends-proxy.transcen.com:8007/nginx_status'
+    restart: always
     volumes:
       - ./certs/ca.crt:/certs/ca.crt:ro
 
@@ -418,6 +443,7 @@ services:
     env_file: ./docker_env/exporter.env
     command:
       - '--nginx.scrape-uri=https://match-proxy.transcen.com:8008/nginx_status'
+    restart: always
     volumes:
       - ./certs/ca.crt:/certs/ca.crt:ro
 
@@ -429,6 +455,7 @@ services:
     depends_on:
       - friends_db
     env_file: ./docker_env/friends.env
+    restart: always
 
   user_db_exporter:
     image: prometheuscommunity/postgres-exporter:v0.17.1
@@ -438,6 +465,7 @@ services:
     depends_on:
       - user_db
     env_file: ./docker_env/user.env
+    restart: always
 
   auth_db_exporter:
     image: prometheuscommunity/postgres-exporter:v0.17.1
@@ -447,6 +475,7 @@ services:
     depends_on:
       - auth_db
     env_file: ./docker_env/auth.env
+    restart: always
 
   tournament_db_exporter:
     image: prometheuscommunity/postgres-exporter:v0.17.1
@@ -456,6 +485,7 @@ services:
     depends_on:
       - tournament_db
     env_file: ./docker_env/tournament.env
+    restart: always
 
   match_db_exporter:
     image: prometheuscommunity/postgres-exporter:v0.17.1
@@ -465,6 +495,7 @@ services:
     depends_on:
       - match_db
     env_file: ./docker_env/match.env
+    restart: always
 
   game_redis_exporter:
     image: oliver006/redis_exporter:v1.70.0
@@ -474,6 +505,7 @@ services:
     depends_on:
       - game_redis
     env_file: ./docker_env/game.env
+    restart: always
 
   auth_redis_exporter:
     image: oliver006/redis_exporter:v1.70.0
@@ -483,6 +515,7 @@ services:
     depends_on:
       - auth_redis
     env_file: ./docker_env/auth.env
+    restart: always
 
   tournament_redis_exporter:
     image: oliver006/redis_exporter:v1.70.0
@@ -492,6 +525,7 @@ services:
     depends_on:
       - tournament_redis
     env_file: ./docker_env/tournament.env
+    restart: always
 
   match_redis_exporter:
     image: oliver006/redis_exporter:v1.70.0
@@ -501,6 +535,7 @@ services:
     depends_on:
       - match_redis
     env_file: ./docker_env/match.env
+    restart: always
 
   alertmanager:
     image: prom/alertmanager:v0.28.1
@@ -509,6 +544,7 @@ services:
       - app_network
     command:
       - '--config.file=/etc/alertmanager/alertmanager.yml'
+    restart: always
     volumes:
       - ./monitoring/prometheus/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - ./docker_env/alert.url:/etc/alertmanager/alert.url:ro
@@ -534,6 +570,7 @@ services:
       - match_db_exporter
       - game_redis_exporter
       - alertmanager
+    restart: always
     volumes:
       - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus_data:/prometheus
@@ -549,6 +586,7 @@ services:
       - app_network
     depends_on:
       - prometheus
+    restart: always
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/grafana.ini:/etc/grafana/grafana.ini

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -319,7 +319,8 @@ services:
       - ./certs/vault/server.crt:/vault/certs/server.crt:ro
       - ./certs/vault/server.key:/vault/certs/server.key:ro
       - ./certs/ca.crt:/vault/certs/ca.crt:ro
-      - vault_data:/vault/keys
+      - vault_data:/vault/data
+      - vault_keys:/vault/keys
 
   spa_nginx:
     image: nginx:alpine
@@ -613,3 +614,4 @@ volumes:
   prometheus_data:
   grafana_data:
   vault_data:
+  vault_keys:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -319,6 +319,7 @@ services:
       - ./certs/vault/server.crt:/vault/certs/server.crt:ro
       - ./certs/vault/server.key:/vault/certs/server.key:ro
       - ./certs/ca.crt:/vault/certs/ca.crt:ro
+      - vault_data:/vault/keys
 
   spa_nginx:
     image: nginx:alpine
@@ -611,3 +612,4 @@ volumes:
   user_media:
   prometheus_data:
   grafana_data:
+  vault_data:

--- a/docker_env/vault.env
+++ b/docker_env/vault.env
@@ -1,3 +1,5 @@
 VAULT_ADDR=https://0.0.0.0:8200
 VAULT_CACERT="/vault/certs/ca.crt"
 API_KEY_ROTATE_SEC=3600
+VAULT_UNSEAK_KEY_FILE=/vault/keys/unseal_key
+VAULT_ROOT_TOKEN_FILE=/vault/keys/root_token

--- a/vault_service/Dockerfile
+++ b/vault_service/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get update && apt-get -y install \
 	supervisor \
 	tini \
 	gnupg \
-	lsb-release
+	lsb-release \
+	jq
 
 RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
 	echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \


### PR DESCRIPTION
## 概要
<!--対応内容-->
* ホスト側でrebootを行うとvaultのunsealが失敗する問題の修正。
* vaultのデータを永続化
* vaultのunsealに必要な`root_token`と`unseal_key`をファイルに保存するように変更。
* 全てのコンテナに`restart: always`を付与。

## 関連するチケット
<!--関連するissueやドキュメントなど-->
<!--close #issue number-->
close #257 

## レビューしてほしい点
<!--特に気をつけてレビューして欲しい点があれば-->
* rebootしたときに全てのコンテナが正常稼働するか？

## 動作確認方法
<!--共有しないといけない点があれば-->
* make後、ホスト側でreboot等の再起動を実行し、再起動後、サイトが機能するか？